### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/src/contentScripts/praccTeam.ts
+++ b/src/contentScripts/praccTeam.ts
@@ -57,22 +57,34 @@ const loadDescriptionLinks = () => {
     .split(/\s+/)
     .filter((link) => link.trim().startsWith("https://"));
   linksInLines.forEach((link) => {
-    if (new URL(link).hostname.includes("tracker.gg")) {
-      const text = decodeURI(link.split("/")[6]).replace("%23", "#");
-      links.push({ type: "tracker", link, text });
-    } else if (new URL(link).hostname.includes("discord.gg")) {
-      links.push({ type: "discord", link });
-    } else if (new URL(link).hostname.includes("x.com")) {
-      const text = link.split("/")[3];
-      links.push({ type: "x", link, text });
-    } else if (new URL(link).hostname.includes("twitter.com")) {
-      const text = link.split("/")[3];
-      links.push({ type: "x", link, text });
-    } else if (new URL(link).hostname.includes("rib.gg")) {
-      links.push({ type: "rib", link });
-    } else if (new URL(link).hostname.includes("vlr.gg")) {
-      const text = link.split("/")[5];
-      links.push({ type: "vlr", link, text });
+    const hostname = new URL(link).hostname;
+    const allowedHosts = {
+      "tracker.gg": "tracker",
+      "discord.gg": "discord",
+      "x.com": "x",
+      "twitter.com": "x",
+      "rib.gg": "rib",
+      "vlr.gg": "vlr"
+    };
+    if (allowedHosts[hostname]) {
+      let text;
+      switch (hostname) {
+        case "tracker.gg":
+          text = decodeURI(link.split("/")[6]).replace("%23", "#");
+          links.push({ type: allowedHosts[hostname], link, text });
+          break;
+        case "x.com":
+        case "twitter.com":
+          text = link.split("/")[3];
+          links.push({ type: allowedHosts[hostname], link, text });
+          break;
+        case "vlr.gg":
+          text = link.split("/")[5];
+          links.push({ type: allowedHosts[hostname], link, text });
+          break;
+        default:
+          links.push({ type: allowedHosts[hostname], link });
+      }
     }
   });
   linksOutOfDescriptionContainer.classList.add(


### PR DESCRIPTION
Potential fix for [https://github.com/leontm-dev/pracc-optimizer/security/code-scanning/2](https://github.com/leontm-dev/pracc-optimizer/security/code-scanning/2)

To fix the problem, we need to parse the URL and check the hostname against a whitelist of allowed hosts. This ensures that the hostname is exactly what we expect and not just a substring within a potentially malicious URL.

- Parse the URL using the `URL` constructor.
- Extract the hostname from the parsed URL.
- Check if the hostname matches any of the allowed hosts exactly.

We will modify the code in `src/contentScripts/praccTeam.ts` to implement this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
